### PR TITLE
disable auto create topic and add missing topics

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openftth
 appVersion: "0.3.4"
 description: A Helm chart for openftth
-version: 0.3.15
+version: 0.3.16
 type: application
 dependencies:
   - name: elasticsearch

--- a/openftth/charts/strimzi/Chart.yaml
+++ b/openftth/charts/strimzi/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: strimzi
 appVersion: "1.0"
 description: A Helm chart for strimzi kafka
-version: 0.1.14
+version: 0.1.15
 type: application

--- a/openftth/charts/strimzi/templates/connect-cluster-configs-topic.yaml
+++ b/openftth/charts/strimzi/templates/connect-cluster-configs-topic.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: connect-cluster-configs
+  labels:
+    strimzi.io/cluster: "{{ .Release.Name }}-kafka-cluster"
+spec:
+  config:
+    retention.ms: -1
+  partitions: 1
+  replicas: 1

--- a/openftth/charts/strimzi/templates/connect-cluster-offsets-unique.yaml
+++ b/openftth/charts/strimzi/templates/connect-cluster-offsets-unique.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: consumer-offsets---84e7a678d08f4bd226872e5cdd4eb527fadc1c6a
+  labels:
+    strimzi.io/cluster: "{{ .Release.Name }}-kafka-cluster"
+spec:
+  config:
+    cleanup.policy: compact
+  topicName: __consumer_offsets
+  partitions: 50
+  replicas: 3

--- a/openftth/charts/strimzi/templates/connect-cluster-offsets.yaml
+++ b/openftth/charts/strimzi/templates/connect-cluster-offsets.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: connect-cluster-offsets
+  labels:
+    strimzi.io/cluster: "{{ .Release.Name }}-kafka-cluster"
+spec:
+  config:
+    cleanup.policy: compact
+  partitions: 25
+  replicas: 1

--- a/openftth/charts/strimzi/templates/connect-cluster-status.yaml
+++ b/openftth/charts/strimzi/templates/connect-cluster-status.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: connect-cluster-status
+  labels:
+    strimzi.io/cluster: "{{ .Release.Name }}-kafka-cluster"
+spec:
+  config:
+    cleanup.policy: compact
+  partitions: 5
+  replicas: 1

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -8,7 +8,7 @@ strimzi:
   kafka:
     replicas: 3
     config:
-      autoCreateTopicsEnable: true
+      autoCreateTopicsEnable: false
       replicationFactorOffsets: 3
       replicationFactorStateLog: 3
       stateLogMinIsr: 2

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -8,7 +8,7 @@ strimzi:
   kafka:
     replicas: 1
     config:
-      autoCreateTopicsEnable: true
+      autoCreateTopicsEnable: false
       replicationFactorOffsets: 1
       replicationFactorStatelog: 1
       stateLogMinIsr: 1


### PR DESCRIPTION
Disable auto creating topics by consumers or producers to avoid strimzi/strimzi-kafka-operator/issues/1572 the following issue where a race condition can occur and topics won't be created with the correct retention time and replication factor because the default values will be used by being auto-created by the consumer or producer.