### PR TITLE
adds postgis basemap chart

### DIFF
--- a/openftth/charts/gdb-integrator/values.yaml
+++ b/openftth/charts/gdb-integrator/values.yaml
@@ -10,8 +10,8 @@ loglevel: "Information"
 backup: true
 
 resources:
- requests:
-   memory: 300Mi
+  requests:
+    memory: 300Mi
 
 application:
   tolerance: "0.01"

--- a/openftth/charts/postgis-basemap/Chart.yaml
+++ b/openftth/charts/postgis-basemap/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postgis-basemap
+appVersion: "12.1"
+description: A Helm chart for postgis
+version: 0.1.0
+type: application

--- a/openftth/charts/postgis-basemap/templates/secret.yaml
+++ b/openftth/charts/postgis-basemap/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-postgis
+data:
+  username: {{ .Values.username | b64enc }}
+  password: {{ .Values.password | b64enc }}

--- a/openftth/charts/postgis-basemap/templates/service.yaml
+++ b/openftth/charts/postgis-basemap/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Chart.Name }}
+spec:
+  type: {{ .Values.serviceType }}
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: {{ .Release.Name }}-{{ .Chart.Name }}

--- a/openftth/charts/postgis-basemap/templates/statefulset.yaml
+++ b/openftth/charts/postgis-basemap/templates/statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}
+spec:
+  serviceName: {{ .Release.Name }}-{{ .Chart.Name }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-{{ .Chart.Name }}
+        backup: "{{ .Values.backup }}"
+    spec:
+      containers:
+        - name: {{ .Release.Name }}-{{ .Chart.Name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          resources:
+            requests:
+              memory: {{ .Values.resources.requests.memory }}
+          env:
+            - name: POSTGRES_DBNAME
+              value: OPEN_FTTH
+            - name: WAL_LEVEL
+              value: logical
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-postgis
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: {{ .Release.Name }}-{{ .Chart.Name }}-postgis
+          ports:
+            - containerPort: 5432
+              name: {{ .Chart.Name }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-{{ .Chart.Name }}-data
+              mountPath: /var/lib/postgresql/
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ .Release.Name }}-{{ .Chart.Name }}-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.volumeClaim.storageClassName }}
+        storageClassName: {{ .Values.volumeClaim.storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.volumeClaim.storage }}

--- a/openftth/charts/postgis-basemap/values.yaml
+++ b/openftth/charts/postgis-basemap/values.yaml
@@ -1,0 +1,17 @@
+username: postgres
+password: postgres
+
+serviceType: LoadBalancer
+backup: true
+
+image:
+  repository: kartoza/postgis
+  tag: 12.1
+
+volumeClaim:
+  storageClassName: ""
+  storage: 10Gi
+
+resources:
+  requests:
+    memory: 1000Mi

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -102,6 +102,17 @@ postgis:
     storageClassName: ""
     storage: 10Gi
 
+postgis-basemap:
+  username: postgres
+  password: postgres
+  serviceType: LoadBalancer
+  volumeClaim:
+    storageClassName: ""
+    storage: 10Gi
+  resources:
+    requests:
+      memory: 1000Mi
+
 frontend:
   graphqlServer:
 

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -102,6 +102,17 @@ postgis:
     storageClassName: ""
     storage: 10Gi
 
+postgis-basemap:
+  username: postgres
+  password: postgres
+  serviceType: LoadBalancer
+  volumeClaim:
+    storageClassName: ""
+    storage: 10Gi
+  resources:
+    requests:
+      memory: 0Mi
+
 frontend:
   graphqlServer:
 


### PR DESCRIPTION
Adds the PostGIS base map chart. The purpose of the PostGIS database is to hold the base map data separately from the main PostGIS that holds the segments and nodes.