### PR TITLE
removes wal level

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openftth
 appVersion: "0.3.4"
 description: A Helm chart for openftth
-version: 0.4.0
+version: 0.4.1
 type: application
 dependencies:
   - name: elasticsearch

--- a/openftth/charts/postgis-basemap/templates/statefulset.yaml
+++ b/openftth/charts/postgis-basemap/templates/statefulset.yaml
@@ -23,8 +23,6 @@ spec:
           env:
             - name: POSTGRES_DBNAME
               value: BASEMAP
-            - name: WAL_LEVEL
-              value: logical
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Removes wal-level from postgis-basemap since no connector is needed for it.