### PR TITLE
adds annotations for postgres services

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openftth
 appVersion: "0.3.4"
 description: A Helm chart for openftth
-version: 0.4.1
+version: 0.4.2
 type: application
 dependencies:
   - name: elasticsearch

--- a/openftth/charts/postgis-basemap/Chart.yaml
+++ b/openftth/charts/postgis-basemap/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgis-basemap
 appVersion: "12.1"
 description: A Helm chart for postgis
-version: 0.1.1
+version: 0.1.2
 type: application

--- a/openftth/charts/postgis-basemap/templates/service.yaml
+++ b/openftth/charts/postgis-basemap/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}
   labels:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
+  annotations: {{ toYaml .Values.serviceAnnotations | nindent 4 }}
 spec:
   type: {{ .Values.serviceType }}
   ports:

--- a/openftth/charts/postgis-basemap/values.yaml
+++ b/openftth/charts/postgis-basemap/values.yaml
@@ -15,3 +15,5 @@ volumeClaim:
 resources:
   requests:
     memory: 1000Mi
+
+serviceAnnotations: {}

--- a/openftth/charts/postgis/Chart.yaml
+++ b/openftth/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgis
 appVersion: "12.1"
 description: A Helm chart for postgis
-version: 0.1.5
+version: 0.1.6
 type: application

--- a/openftth/charts/postgis/templates/service.yaml
+++ b/openftth/charts/postgis/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}
   labels:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
+  annotations: {{ toYaml .Values.serviceAnnotations | nindent 4 }}
 spec:
   type: {{ .Values.serviceType }}
   ports:

--- a/openftth/charts/postgis/values.yaml
+++ b/openftth/charts/postgis/values.yaml
@@ -11,3 +11,5 @@ image:
 volumeClaim:
   storageClassName: ""
   storage: 10Gi
+
+serviceAnnotations: {}

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -98,6 +98,7 @@ postgis:
   username: postgres
   password:
   serviceType: LoadBalancer
+  serviceAnnotations: {}
   volumeClaim:
     storageClassName: ""
     storage: 10Gi
@@ -106,6 +107,7 @@ postgis-basemap:
   username: postgres
   password: postgres
   serviceType: LoadBalancer
+  serviceAnnotations: {}
   volumeClaim:
     storageClassName: ""
     storage: 10Gi

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -98,6 +98,7 @@ postgis:
   username: postgres
   password: postgres
   serviceType: LoadBalancer
+  annotations: {}
   volumeClaim:
     storageClassName: ""
     storage: 10Gi
@@ -106,6 +107,7 @@ postgis-basemap:
   username: postgres
   password: postgres
   serviceType: LoadBalancer
+  annotations: {}
   volumeClaim:
     storageClassName: ""
     storage: 10Gi

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -98,7 +98,7 @@ postgis:
   username: postgres
   password: postgres
   serviceType: LoadBalancer
-  annotations: {}
+  serviceAnnotations: {}
   volumeClaim:
     storageClassName: ""
     storage: 10Gi
@@ -107,7 +107,7 @@ postgis-basemap:
   username: postgres
   password: postgres
   serviceType: LoadBalancer
-  annotations: {}
+  serviceAnnotations: {}
   volumeClaim:
     storageClassName: ""
     storage: 10Gi


### PR DESCRIPTION
Adds annotations for postgres service using Helm templates. This is needed in some cloud environments where the default loadbalancers requires annotations to change the default behavior of the loadbalancer.