### PR TITLE
set recreate strategy for gdb-integrator

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openftth
 appVersion: "0.3.4"
 description: A Helm chart for openftth
-version: 0.4.3
+version: 0.4.4
 type: application
 dependencies:
   - name: elasticsearch

--- a/openftth/charts/gdb-integrator/Chart.yaml
+++ b/openftth/charts/gdb-integrator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gdb-integrator
 appVersion: "2.3.4"
 description: A Helm chart for gdb-integrator
-version: 0.1.18
+version: 0.1.19
 type: application

--- a/openftth/charts/gdb-integrator/templates/deployment.yaml
+++ b/openftth/charts/gdb-integrator/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicas }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ .Release.Name }}-{{ .Chart.Name }}


### PR DESCRIPTION
To avoid issues where multiple instances are producing the same messages doing a new release, set the strategy to be of type "Recreate".