### PR TITLE
upgrade strimzi to version 0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Helm Chart for OPEN-FTTH
 
 ## Note
-g
 This chart is still under development and is not meant for use yet.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Helm Chart for OPEN-FTTH
 
 ## Note
-
+g
 This chart is still under development and is not meant for use yet.
 
 ## Requirements

--- a/openftth/charts/strimzi/templates/kafka.yaml
+++ b/openftth/charts/strimzi/templates/kafka.yaml
@@ -6,10 +6,17 @@ spec:
   kafka:
     replicas: {{ .Values.kafka.replicas }}
     listeners:
-      plain: {}
-      tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
       {{- if .Values.kafka.external.type }}
-      external:
+      - name: external
+        port: 9094
         type: {{ .Values.kafka.external.type }}
         tls: {{ .Values.kafka.external.tls }}
       {{- end }}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,7 +15,7 @@ helm repo update
 # Install strimzi
 helm install strimzi strimzi/strimzi-kafka-operator \
      -n openftth \
-     --version 0.19
+     --version 0.20
 
 # Install loki
 helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi --version 2.3.0


### PR DESCRIPTION
Upgrade strimzi to 0.20. The upgrade requires uninstalling the current strimzi operator (which will take down all kafka resources). After install the kafka operator and do a helm upgrade to support the changes in the KafkaCluster custom type.
