### PR TITLE
removes unused elk stack configs

### DIFF
--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -119,20 +119,3 @@ postgis-basemap:
   resources:
     requests:
       memory: 1000Mi
-
-kibana:
-  elasticsearchHosts: http://openftth-elasticsearch-master:9200
-
-elasticsearch:
-  clusterName: "openftth-elasticsearch"
-  antiAffinity: hard
-  replicas: 3
-  minimumMasterNodes: 2
-  volumeClaimTemplate:
-    resources:
-      requests:
-        storage: 10Gi
-
-fluentd-elasticsearch:
-  elasticsearch:
-    hosts: ["openftth-elasticsearch-master:9200"]


### PR DESCRIPTION
Remove the unused ELK configs from prod config after switch to Loki stack for logging.
