### PR TITLE
now only package helm chart on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,5 +39,6 @@ workflows:
     jobs:
       - package-and-upload:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only:
+                - master


### PR DESCRIPTION
Now only package and publish chart on master branch to fix the issue where the job was running on other branches.
