### PR TITLE
Pointing to wrong helm repo and add version number for loki chart

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,7 @@ kubectl create namespace openftth
 
 # Install Strimzi
 helm repo add strimzi https://strimzi.io/charts/
-helm repo add grafana https://grafana.github.io/loki/charts
+helm repo add grafana https://grafana.github.io/helm-charts
 
 helm repo update
 
@@ -13,7 +13,7 @@ helm repo update
 helm install strimzi strimzi/strimzi-kafka-operator -n openftth --version 0.19
 
 # Install loki
-helm upgrade --install loki --namespace=openftth grafana/loki-stack  --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi --version jk
+helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi
 
 # This is needed to make sure that the strimzi custom types are being registered
 sleep 1s

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,7 @@ helm repo update
 helm install strimzi strimzi/strimzi-kafka-operator -n openftth --version 0.19
 
 # Install loki
-helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi
+helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi --version 2.3.0
 
 # This is needed to make sure that the strimzi custom types are being registered
 sleep 1s


### PR DESCRIPTION
* Changes the path for the loki helm repo to "https://grafana.github.io/helm-charts".
* Adds version number for the used Loki helm chart, for now 2.3.0.