### PR TITLE
Ingress-controller setup

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openftth
 appVersion: "0.4.0"
 description: A Helm chart for openftth
-version: 0.6.12
+version: 0.7.0
 type: application

--- a/openftth/charts/api-gateway/templates/service.yaml
+++ b/openftth/charts/api-gateway/templates/service.yaml
@@ -1,19 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .Chart.Name }}
+  name: {{ .Release.Name}}-{{ .Chart.Name }}
   labels:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: ClusterIP
   ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 80
-    - name: https
-      protocol: TCP
-      port: 443
-      targetPort: 443
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
   selector:
     app: {{ .Release.Name }}-{{ .Chart.Name }}

--- a/openftth/charts/api-gateway/values.yaml
+++ b/openftth/charts/api-gateway/values.yaml
@@ -2,7 +2,6 @@ replicas: 1
 storage: 1Gi
 storageClassName: ""
 loglevel: "Information"
-serviceType: LoadBalancer
 
 image:
   repository: openftth/api-gateway

--- a/openftth/charts/desktop-bridge/templates/service.yaml
+++ b/openftth/charts/desktop-bridge/templates/service.yaml
@@ -5,15 +5,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: ClusterIP
   ports:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 5000
-    - name: https
-      protocol: TCP
-      port: 443
       targetPort: 5000
   selector:
     app: {{ .Release.Name }}-{{ .Chart.Name }}

--- a/openftth/charts/desktop-bridge/values.yaml
+++ b/openftth/charts/desktop-bridge/values.yaml
@@ -1,6 +1,5 @@
 replicas: 1
 loglevel: "Information"
-serviceType: LoadBalancer
 
 image:
   repository: openftth/desktop-bridge

--- a/openftth/charts/frontend/templates/cm.yaml
+++ b/openftth/charts/frontend/templates/cm.yaml
@@ -6,6 +6,7 @@ data:
   config-env.js: |
     window.config_MAPBOX_API_KEY = "{{ .Values.mapbox.apiKey }}";
     window.config_MAPBOX_STYLE_URL = "{{ .Values.mapbox.styleUrl }}";
-    window.config_API_GATEWAY_URI = "{{ .Values.apiGatewayUri }}";
+    window.config_API_GATEWAY_HTTP_URI = "{{ .Values.apiGatewayHttpUri }}";
+    window.config_API_GATEWAY_WS_URI = "{{ .Values.apiGatewayWsUri }}";
     window.config_DESKTOP_BRIDGE_URI = "{{ .Values.desktopBridgeUri }}";
     window.config_KEYCLOAK_URI = "{{ .Values.keyCloakUri }}";

--- a/openftth/charts/frontend/templates/cm.yaml
+++ b/openftth/charts/frontend/templates/cm.yaml
@@ -8,3 +8,4 @@ data:
     window.config_MAPBOX_STYLE_URL = "{{ .Values.mapbox.styleUrl }}";
     window.config_API_GATEWAY_URI = "{{ .Values.apiGatewayUri }}";
     window.config_DESKTOP_BRIDGE_URI = "{{ .Values.desktopBridgeUri }}";
+    window.config_KEYCLOAK_URI = "{{ .Values.keyCloakUri }}";

--- a/openftth/charts/frontend/templates/service.yaml
+++ b/openftth/charts/frontend/templates/service.yaml
@@ -1,19 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .Chart.Name }}
+  name: {{ .Release.Name}}-{{ .Chart.Name }}
   labels:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: ClusterIP
   ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 80
-    - name: https
-      protocol: TCP
-      port: 443
-      targetPort: 443
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
   selector:
     app: {{ .Release.Name }}-{{ .Chart.Name }}

--- a/openftth/charts/frontend/values.yaml
+++ b/openftth/charts/frontend/values.yaml
@@ -11,3 +11,4 @@ mapbox:
 
 desktopBridgeUri: ""
 apiGatewayUri: ""
+keyCloakUri: ""

--- a/openftth/charts/frontend/values.yaml
+++ b/openftth/charts/frontend/values.yaml
@@ -10,5 +10,6 @@ mapbox:
   styleUrl: ""
 
 desktopBridgeUri: ""
-apiGatewayUri: ""
+apiGatewayHttpUri: ""
+apiGatewayWsUri: ""
 keyCloakUri: ""

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -24,5 +24,12 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ .Release.Name}}-desktop-bridge
+          serviceName: {{ .Release.Name}}-api-gateway
+          servicePort: 80
+  - host: auth.openftth.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: keycloak
           servicePort: 80

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Name }}
 spec:
   rules:
-  - host: frontend.openftth.com
+  - host: openftth.com
     http:
       paths:
       - path: /

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: openftth-ingress
+  namespace: {{ .Release.Name }}
+spec:
+  rules:
+  - host: frontend.openftth.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name}}-frontend
+          servicePort: 80
+  - host: desktop-bridge.openftth.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name}}-desktop-bridge
+          servicePort: 80
+  - host: api-gateway.openftth.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name}}-desktop-bridge
+          servicePort: 80

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -5,28 +5,28 @@ metadata:
   namespace: {{ .Release.Name }}
 spec:
   rules:
-  - host: openftth.com
+  - host: openftth.local
     http:
       paths:
       - path: /
         backend:
           serviceName: {{ .Release.Name}}-frontend
           servicePort: 80
-  - host: desktop-bridge.openftth.com
+  - host: desktop-bridge.openftth.local
     http:
       paths:
       - path: /
         backend:
           serviceName: {{ .Release.Name}}-desktop-bridge
           servicePort: 80
-  - host: api-gateway.openftth.com
+  - host: api-gateway.openftth.local
     http:
       paths:
       - path: /
         backend:
           serviceName: {{ .Release.Name}}-api-gateway
           servicePort: 80
-  - host: auth.openftth.com
+  - host: auth.openftth.local
     http:
       paths:
       - path: /

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -40,7 +40,6 @@ api-gateway:
   replicas: 1
   storage: 1Gi
   loglevel: "Information"
-  serviceType: LoadBalancer
   storageClassName: ""
 
 route-network-validator:
@@ -95,7 +94,6 @@ postgis-connector:
 
 frontend:
   replicas: 1
-  serviceType: LoadBalancer
   mapbox:
     apiKey: ""
     styleUrl: ""
@@ -127,4 +125,3 @@ postgis-basemap:
 desktop-bridge:
   replicas: 1
   loglevel: "Information"
-  serviceType: LoadBalancer

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -98,7 +98,8 @@ frontend:
     apiKey: ""
     styleUrl: ""
   desktopBridgeUri: ""
-  apiGatewayUri: ""
+  apiGatewayHttpUri: ""
+  apiGatewayWsUri: ""
   keyCloakUri: ""
 
 postgis:

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -101,6 +101,7 @@ frontend:
     styleUrl: ""
   desktopBridgeUri: ""
   apiGatewayUri: ""
+  keyCloakUri: ""
 
 postgis:
   username: postgres

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -97,9 +97,9 @@ frontend:
   mapbox:
     apiKey: ""
     styleUrl: ""
-  desktopBridgeUri: "desktop-bridge.openftth.com"
-  apiGatewayUri: "api-gateway.openftth.com"
-  keyCloakUri: "http://auth.openftth.com/auth"
+  desktopBridgeUri: "desktop-bridge.openftth.local"
+  apiGatewayUri: "api-gateway.openftth.local"
+  keyCloakUri: "http://auth.openftth.local/auth"
 
 postgis:
   username: postgres

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -40,7 +40,6 @@ api-gateway:
   replicas: 1
   storage: 1Gi
   loglevel: "Information"
-  serviceType: LoadBalancer
   storageClassName: ""
 
 route-network-validator:
@@ -95,13 +94,12 @@ postgis-connector:
 
 frontend:
   replicas: 1
-  serviceType: LoadBalancer
   mapbox:
     apiKey: ""
     styleUrl: ""
   desktopBridgeUri: "desktop-bridge.openftth.com"
-  apiGatewayUri: "https://api-gateway.openftth.com"
-  keyCloakUri: "https://auth.openftth.com"
+  apiGatewayUri: "api-gateway.openftth.com"
+  keyCloakUri: "http://auth.openftth.com/auth"
 
 postgis:
   username: postgres
@@ -127,4 +125,3 @@ postgis-basemap:
 desktop-bridge:
   replicas: 1
   loglevel: "Information"
-  serviceType: LoadBalancer

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -63,7 +63,7 @@ route-network-service:
   loglevel: "Information"
 
 gdb-integrator:
-  replicas: 1
+  replicas: 0
   loglevel: "Information"
   storage: 1Gi
   postgis:
@@ -99,8 +99,8 @@ frontend:
   mapbox:
     apiKey: ""
     styleUrl: ""
-  desktopBridgeUri: ""
-  apiGatewayUri: ""
+  desktopBridgeUri: "desktop-bridge.openftth.com"
+  apiGatewayUri: "api-gateway.openftth.com"
 
 postgis:
   username: postgres

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -63,7 +63,7 @@ route-network-service:
   loglevel: "Information"
 
 gdb-integrator:
-  replicas: 0
+  replicas: 1
   loglevel: "Information"
   storage: 1Gi
   postgis:

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -97,8 +97,9 @@ frontend:
   mapbox:
     apiKey: ""
     styleUrl: ""
-  desktopBridgeUri: "desktop-bridge.openftth.local"
-  apiGatewayUri: "api-gateway.openftth.local"
+  desktopBridgeUri: "ws://desktop-bridge.openftth.local"
+  apiGatewayHttpUri: "http://api-gateway.openftth.local"
+  apiGatewayWsUri: "ws://api-gateway.openftth.local"
   keyCloakUri: "http://auth.openftth.local/auth"
 
 postgis:

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -100,7 +100,8 @@ frontend:
     apiKey: ""
     styleUrl: ""
   desktopBridgeUri: "desktop-bridge.openftth.com"
-  apiGatewayUri: "api-gateway.openftth.com"
+  apiGatewayUri: "https://api-gateway.openftth.com"
+  keyCloakUri: "https://auth.openftth.com"
 
 postgis:
   username: postgres

--- a/scripts/keycloak/client.json
+++ b/scripts/keycloak/client.json
@@ -1,6 +1,6 @@
 {
   "clientId": "openftth-frontend",
-  "redirectUris": ["https://openftth.com/*"],
+  "redirectUris": ["http://openftth.local/*"],
   "publicClient": true,
-  "webOrigins": ["https://openftth.com"]
+  "webOrigins": ["http://openftth.local"]
 }

--- a/scripts/keycloak/client.json
+++ b/scripts/keycloak/client.json
@@ -1,6 +1,6 @@
 {
   "clientId": "openftth-frontend",
-  "redirectUris": ["http://localhost:3000/*"],
+  "redirectUris": ["https://openftth.com/*"],
   "publicClient": true,
-  "webOrigins": ["http://localhost:3000"]
+  "webOrigins": ["https://openftth.com"]
 }

--- a/scripts/keycloak/keycloak-default-setup.sh
+++ b/scripts/keycloak/keycloak-default-setup.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 NEW_REALM="openftth"
-KEYCLOAK_URL=http://$(kubectl describe service keycloak -n openftth | \
-                          grep LoadBalancer | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+')
+KEYCLOAK_URL=http://auth.openftth.local
 KEYCLOAK_REALM="master"
 KEYCLOAK_USER="user"
 KEYCLOAK_SECRET=$(kubectl get secret --namespace openftth keycloak-env-vars \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,7 @@ kubectl create namespace openftth
 helm repo add strimzi https://strimzi.io/charts/
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
 helm repo update
 
@@ -18,6 +19,11 @@ helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafan
 
 # Install Keycloak
 helm upgrade --install keycloak bitnami/keycloak -n openftth --version 1.2.0
+
+# Install Nginx-Ingress
+helm install nginx-ingress ingress-nginx/ingress-nginx \
+    --namespace openftth \
+    --set controller.replicaCount=1
 
 # This is needed to make sure that the strimzi custom types are being registered
 sleep 1s

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ helm install strimzi strimzi/strimzi-kafka-operator -n openftth --version 0.19
 helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi --version 2.3.0
 
 # Install Keycloak
-helm upgrade --install keycloak bitnami/keycloak -n openftth --version 1.2.0
+helm upgrade --install keycloak bitnami/keycloak -n openftth --version 1.2.0 --set service.type=ClusterIP
 
 # Install Nginx-Ingress
 helm install nginx-ingress ingress-nginx/ingress-nginx \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,13 +20,10 @@ helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafan
 # Install Keycloak
 helm upgrade --install keycloak bitnami/keycloak -n openftth --version 1.2.0 --set service.type=ClusterIP
 
+# Install OpenFTTH
+helm install openftth openftth -n openftth
+
 # Install Nginx-Ingress
 helm install nginx-ingress ingress-nginx/ingress-nginx \
     --namespace openftth \
     --set controller.replicaCount=1
-
-# This is needed to make sure that the strimzi custom types are being registered
-sleep 1s
-
-# Install OpenFTTH
-helm install openftth openftth -n openftth


### PR DESCRIPTION
Adds ingress-controller using `NGINX-ingress`. Multiple services which before had their own loadbalancer now defaults to `ClusterIP`.

* Desktop-bridge
* Frontend
* Api-gateway
* Keycloak

The pull-request also contains an updated setup script and a new folder that contains a default setup for keycloak. This setup also creates a test user that can be used for development and testing purposes.