### PR TITLE
TLS setup with lets-encrypt for nginx ingress

### DIFF
--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -1,9 +1,23 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: openftth-ingress
+  name: {{ .Release.Name }}-ingress
   namespace: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    {{ if (eq .Values.ingress.tls true) }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{ end }}
 spec:
+  {{ if (eq .Values.ingress.tls true) }}
+  tls:
+  - hosts:
+    - openftth.local
+    - desktop-bridge.openftth.local
+    - api-gateway.openftth.local
+    - auth.openftth.local
+    secretName: tls-secret
+  {{ end }}
   rules:
   - host: openftth.local
     http:

--- a/openftth/templates/issuer.yaml
+++ b/openftth/templates/issuer.yaml
@@ -1,18 +1,16 @@
+{{ if (eq .Values.ingress.tls true) }}
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: {{ .Release.Name }}-letsencrypt
 spec:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: MY_EMAIL_ADDRESS
+    server: {{ .Values.tls.server }}
+    email: {{ .Values.tls.email }}
     privateKeySecretRef:
       name: letsencrypt
     solvers:
     - http01:
         ingress:
           class: nginx
-          podTemplate:
-            spec:
-              nodeSelector:
-                "kubernetes.io/os": linux
+{{ end }}

--- a/openftth/templates/issuer.yaml
+++ b/openftth/templates/issuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: {{ .Release.Name }}-letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: MY_EMAIL_ADDRESS
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+          podTemplate:
+            spec:
+              nodeSelector:
+                "kubernetes.io/os": linux

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -126,3 +126,8 @@ postgis-basemap:
 desktop-bridge:
   replicas: 1
   loglevel: "Information"
+
+ingress:
+  tls: true
+  email: ""
+  issuer: "https://acme-v02.api.letsencrypt.org/directory"

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -126,3 +126,8 @@ postgis-basemap:
 desktop-bridge:
   replicas: 1
   loglevel: "Information"
+
+ingress:
+  tls: false
+  email: ""
+  issuer: ""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,13 +13,23 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
 # Install strimzi
-helm install strimzi strimzi/strimzi-kafka-operator -n openftth --version 0.19
+helm install strimzi strimzi/strimzi-kafka-operator \
+     -n openftth \
+     --version 0.19
 
 # Install loki
 helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=10Gi --version 2.3.0
 
 # Install Keycloak
-helm upgrade --install keycloak bitnami/keycloak -n openftth --version 1.2.0 --set service.type=ClusterIP
+helm upgrade --install keycloak bitnami/keycloak -n openftth \
+     --version 1.2.0 \
+     --set service.type=ClusterIP
+
+# Install the cert-manager
+helm install cert-manager jetstack/cert-manager \
+  --namespace openftth \
+  --version v1.1.0 \
+  --set installCRDs=true
 
 # Install OpenFTTH
 helm install openftth openftth -n openftth
@@ -28,9 +38,3 @@ helm install openftth openftth -n openftth
 helm install nginx-ingress ingress-nginx/ingress-nginx \
     --namespace openftth \
     --set controller.replicaCount=1
-
-# Install the cert-manager
-helm install cert-manager jetstack/cert-manager \
-  --namespace openftth \
-  --version v1.1.0 \
-  --set installCRDs=true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,6 +8,7 @@ helm repo add strimzi https://strimzi.io/charts/
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo add jetstack https://charts.jetstack.io
 
 helm repo update
 
@@ -27,3 +28,9 @@ helm install openftth openftth -n openftth
 helm install nginx-ingress ingress-nginx/ingress-nginx \
     --namespace openftth \
     --set controller.replicaCount=1
+
+# Install the cert-manager
+helm install cert-manager jetstack/cert-manager \
+  --namespace openftth \
+  --version v1.1.0 \
+  --set installCRDs=true


### PR DESCRIPTION
Setup for NGINX-ingress TLS with the abilty to toggle TLS on and off for development purposes. The certificates are managed by cert-manager and that dependency has been added to the setup script. Cert-manager will currently only try to issue certificates from letsencrypt because that is the current use-case.