### PR TITLE
Set proxy address forwarding to true

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,8 +22,9 @@ helm upgrade --install loki --namespace=openftth grafana/loki-stack --set grafan
 
 # Install Keycloak
 helm upgrade --install keycloak bitnami/keycloak -n openftth \
-     --version 1.2.0 \
-     --set service.type=ClusterIP
+     --version 2.0.1 \
+     --set service.type=ClusterIP \
+     --set proxyAddressForwarding=true
 
 # Install the cert-manager
 helm install cert-manager jetstack/cert-manager \


### PR DESCRIPTION
Sets the proxy-address-forwarding to true to fix the mixed content issue when using TLS and wanting to access the keycloak admin panel.