### PR TITLE
points to new secret for easy setup for keycloak

### DIFF
--- a/scripts/keycloak/keycloak-default-setup.sh
+++ b/scripts/keycloak/keycloak-default-setup.sh
@@ -4,9 +4,7 @@ NEW_REALM="openftth"
 KEYCLOAK_URL=http://auth.openftth.local
 KEYCLOAK_REALM="master"
 KEYCLOAK_USER="user"
-KEYCLOAK_SECRET=$(kubectl get secret --namespace openftth keycloak-env-vars \
-                          -o jsonpath="{.data.KEYCLOAK_ADMIN_PASSWORD}" | base64 --decode)
-
+KEYCLOAK_SECRET=$(kubectl get secret --namespace openftth keycloak -o jsonpath="{.data.admin-password}" | base64 --decode)
 DIR_PATH=$(dirname $(realpath $0))
 REALM_FILE=$DIR_PATH"/realm.json"
 CLIENT_FILE=$DIR_PATH"/client.json"


### PR DESCRIPTION
Keycloak upgrade to version 2.0.1 which changes the secret name of keycloak. This requires a change in the default setup script that gets the secrets and creates the default realm, client and user.