### PR TITLE
Add missing token claim name

### DIFF
--- a/scripts/keycloak/user-role-client-scope-mapper.json
+++ b/scripts/keycloak/user-role-client-scope-mapper.json
@@ -7,6 +7,7 @@
     "multivalued": "",
     "aggregate.attrs": "",
     "user.attribute": "user_role",
+    "claim.name": "user_role",
     "jsonType.label": "String"
   },
   "name": "user_role",


### PR DESCRIPTION
Adds the missing `claim-name` and sets it to `user_role`. Otherwise the `id-token` won't contain the `user_role`.