### PR TITLE
increase the timeout of the ingress controller

### DIFF
--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Name }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     {{ if (eq .Values.ingress.tls.enabled true) }}
     cert-manager.io/cluster-issuer: letsencrypt
     {{ end }}


### PR DESCRIPTION
Increase the timeout of the ingress controller to avoid WS-clients being disconnected every 1 min. In the future we might handle it server side, so each service sends `KeepAlive` requests to the clients. The timeout is now set to 3600sec (1 hour).