### PR TITLE
Resource limit on API-gateway

### DIFF
--- a/openftth/charts/api-gateway/templates/deployment.yaml
+++ b/openftth/charts/api-gateway/templates/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: {{ .Release.Name }}-{{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        resources:
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+          limits:
+            memory: {{ .Values.resources.limits.memory }}
         readinessProbe:
           exec:
             command:

--- a/openftth/charts/api-gateway/values.yaml
+++ b/openftth/charts/api-gateway/values.yaml
@@ -14,3 +14,9 @@ geoDatabase:
   name: OPEN_FTTH
   username: postgres
   password: postgres
+
+resources:
+  requests:
+    memory: 1500Mi
+  limits:
+    memory: 2000Mi


### PR DESCRIPTION
We have experienced an issue where the API-Gateway got evicted on our test environment because of a new deployment. The issue was that the node ran out of memory when deploying to the same node using rolling release.

Request and limit on memory is required to be set to avoid this issue in the future.