### PR TITLE
Adds tileservers for basemap and route network

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openftth
 appVersion: "0.4.0"
 description: A Helm chart for openftth
-version: 0.7.87
+version: 0.8.0
 type: application

--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openftth
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 description: A Helm chart for openftth
 version: 0.8.0
 type: application

--- a/openftth/charts/frontend/Chart.yaml
+++ b/openftth/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 appVersion: "4.7.4"
 description: A Helm chart for openftth-frontend
-version: 0.2.0
+version: 0.3.0
 type: application

--- a/openftth/charts/frontend/templates/cm.yaml
+++ b/openftth/charts/frontend/templates/cm.yaml
@@ -9,4 +9,5 @@ data:
     window.config_DESKTOP_BRIDGE_URI = "{{ .Values.desktopBridgeUri }}";
     window.config_KEYCLOAK_URI = "{{ .Values.keyCloakUri }}";
     window.config_ROUTE_NETWORK_TILE_SERVER_URI = "{{ .Values.routeNetworkTileServerUri }}";
+    window.config_BASEMAP_TILE_SERVER_URI = "{{ .Values.basemapTileServerUri }}";
     window.config_COLOR_OPTIONS = [{{- range .Values.colorMarkings }}"{{ . -}}",{{ end }}]

--- a/openftth/charts/frontend/templates/cm.yaml
+++ b/openftth/charts/frontend/templates/cm.yaml
@@ -8,4 +8,5 @@ data:
     window.config_API_GATEWAY_WS_URI = "{{ .Values.apiGatewayWsUri }}";
     window.config_DESKTOP_BRIDGE_URI = "{{ .Values.desktopBridgeUri }}";
     window.config_KEYCLOAK_URI = "{{ .Values.keyCloakUri }}";
+    window.config_ROUTE_NETWORK_TILE_SERVER_URI = "{{ .Values.routeNetworkTileServerUri }}";
     window.config_COLOR_OPTIONS = [{{- range .Values.colorMarkings }}"{{ . -}}",{{ end }}]

--- a/openftth/charts/frontend/templates/deployment.yaml
+++ b/openftth/charts/frontend/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicas }}
-
   selector:
     matchLabels:
       app: {{ .Release.Name }}-{{ .Chart.Name }}

--- a/openftth/charts/frontend/values.yaml
+++ b/openftth/charts/frontend/values.yaml
@@ -14,6 +14,7 @@ apiGatewayHttpUri: ""
 apiGatewayWsUri: ""
 keyCloakUri: ""
 routeNetworkTileServerUri: ""
+basemapTileServerUri: ""
 colorMarkings:
   - Blue
   - Red

--- a/openftth/charts/frontend/values.yaml
+++ b/openftth/charts/frontend/values.yaml
@@ -13,6 +13,7 @@ desktopBridgeUri: ""
 apiGatewayHttpUri: ""
 apiGatewayWsUri: ""
 keyCloakUri: ""
+routeNetworkTileServerUri: ""
 colorMarkings:
   - Blue
   - Red

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -45,10 +45,17 @@ spec:
         backend:
           serviceName: keycloak
           servicePort: 80
-  - host: {{ .Values.ingress.domainNames.tileServer }}
+  - host: {{ .Values.ingress.domainNames.tileServerRouteNetwork }}
     http:
       paths:
       - path: /
         backend:
           serviceName: openftth-routenetwork-tileserver-mbtileserver
+          servicePort: 80
+  - host: {{ .Values.ingress.domainNames.tileServerBasemap }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: openftth-basemap-tileserver-mbtileserver
           servicePort: 80

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -45,3 +45,10 @@ spec:
         backend:
           serviceName: keycloak
           servicePort: 80
+  - host: {{ .Values.ingress.domainNames.tileServer }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: openftth-tileserver-mbtileserver
+          servicePort: 80

--- a/openftth/templates/ingress.yaml
+++ b/openftth/templates/ingress.yaml
@@ -50,5 +50,5 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: openftth-tileserver-mbtileserver
+          serviceName: openftth-routenetwork-tileserver-mbtileserver
           servicePort: 80

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -143,3 +143,4 @@ ingress:
     desktopBridge:
     apiGateway: 
     auth:
+    tileServer: 

--- a/openftth/values-prod.yaml
+++ b/openftth/values-prod.yaml
@@ -105,6 +105,7 @@ frontend:
   apiGatewayHttpUri: ""
   apiGatewayWsUri: ""
   keyCloakUri: ""
+  routeNetworkTileServerUri: ""
 
 postgis:
   username: postgres
@@ -143,4 +144,5 @@ ingress:
     desktopBridge:
     apiGateway: 
     auth:
-    tileServer: 
+    tileServerRouteNetwork:
+    tileServerBasemap:

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -143,3 +143,4 @@ ingress:
     desktopBridge: desktop-bridge.openftth.local
     apiGateway: api-gateway.openftth.local
     auth: auth.openftth.local
+    tileServer: tiles.openftth.local

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -105,6 +105,7 @@ frontend:
   apiGatewayHttpUri: "http://api-gateway.openftth.local"
   apiGatewayWsUri: "ws://api-gateway.openftth.local"
   keyCloakUri: "http://auth.openftth.local/auth"
+  routeNetworkTileServerUri: "http://tiles.openftth.local"
 
 postgis:
   username: postgres

--- a/openftth/values.yaml
+++ b/openftth/values.yaml
@@ -105,7 +105,7 @@ frontend:
   apiGatewayHttpUri: "http://api-gateway.openftth.local"
   apiGatewayWsUri: "ws://api-gateway.openftth.local"
   keyCloakUri: "http://auth.openftth.local/auth"
-  routeNetworkTileServerUri: "http://tiles.openftth.local"
+  routeNetworkTileServerUri: "http://tiles-routenetwork.openftth.local"
 
 postgis:
   username: postgres
@@ -144,4 +144,5 @@ ingress:
     desktopBridge: desktop-bridge.openftth.local
     apiGateway: api-gateway.openftth.local
     auth: auth.openftth.local
-    tileServer: tiles.openftth.local
+    tileServerRouteNetwork: tiles-routenetwork.openftth.local
+    tileServerBasemap: tiles-basemap.openftth.local

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,14 +60,8 @@ helm install openftth openftth --namespace openftth
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
      --set schedule="*/30 * * * *" \
-     --set commandArgs='tippecanoe -z22 -o /data/out.mbtiles /data/out.geojson --force' \
-     --set storage.enabled=true \
-     --set gdal.enabled=true \
-     --set gdal.commandArgs='\
-           ogr2ogr -f GeoJSON /data/route_segments.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" \
-                   -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment WHERE route_network.route_segment.marked_to_be_deleted = false" && \
-           ogr2ogr -f GeoJSON /data/route_nodes.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" \
-                   -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_node WHERE route_network.route_node.marked_to_be_deleted = false"'
+     --set commandArgs='tippecanoe -z22 -o /data/route_network.mbtiles /data/out.geojson --force' \
+     --set storage.enabled=true
 
 # Install Mbtileserver
 helm upgrade --install openftth-tileserver dax/mbtileserver \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,13 +56,22 @@ helm install openftth-event-store bitnami/postgresql \
 # Install OpenFTTH
 helm install openftth openftth --namespace openftth
 
-# Install Mbtileserver
+# Install Mbtileserver route-network
 helm upgrade --install openftth-routenetwork-tileserver dax/mbtileserver \
-  --version 2.0.0 \
+  --version 2.1.0 \
   --namespace openftth \
   --set service.type=NodePort \
   --set storage.size=1Gi \
   --set 'commandArgs={--enable-reload-signal, --disable-preview, -d, /data}'
+
+# Install Mbtileserver base-map
+helm upgrade --install openftth-basemap-tileserver dax/mbtileserver \
+  --version 2.1.0 \
+  --namespace openftth \
+  --set image.tag=danish-1621934598 \
+  --set service.type=LoadBalancer \
+  --set storage.enabled=false \
+  --set 'commandArgs={--enable-reload-signal, -d, /tilesets}'
 
 # Install Tippecanoe
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,11 +59,17 @@ helm install openftth openftth --namespace openftth
 # Install Tippecanoe
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
-     --set schedule="*/10 * * * *" \
-     --set commandArgs='tippecanoe -z22 --full-detail=10 --low-detail=10 --generate-ids -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force '  \
+     --set schedule="*/30 * * * *" \
+     --set commandArgs='\
+           tippecanoe -z22 --full-detail=10 --low-detail=10 --generate-ids -o /data/route_segments.mbtiles /data/route_segments.geojson --force && \
+           tippecanoe -z22 -Bg --full-detail=10 --low-detail=10 --generate-ids -o /data/route_nodes.mbtiles /data/route_nodes.geojson --force'  \
      --set storage.enabled=true \
      --set gdal.enabled=true \
-     --set gdal.commandArgs='ogr2ogr -f GeoJSON /data/output.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment WHERE route_network.route_segment.marked_to_be_deleted = false"'
+     --set gdal.commandArgs='\
+           ogr2ogr -f GeoJSON /data/route_segments.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" \
+                   -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment WHERE route_network.route_segment.marked_to_be_deleted = false" && \
+           ogr2ogr -f GeoJSON /data/route_nodes.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" \
+                   -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_node WHERE route_network.route_node.marked_to_be_deleted = false"'
 
 # Install Mbtileserver
 helm upgrade --install openftth-tileserver dax/mbtileserver \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,7 +60,7 @@ helm install openftth openftth --namespace openftth
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
      --set schedule="*/10 * * * *" \
-     --set commandArgs='tippecanoe -z24 --generate-ids -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force '  \
+     --set commandArgs='tippecanoe -z22 --full-detail=10 --low-detail=10 --generate-ids -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force '  \
      --set storage.enabled=true \
      --set gdal.enabled=true \
      --set gdal.commandArgs='ogr2ogr -f GeoJSON /data/output.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment WHERE route_network.route_segment.marked_to_be_deleted = false"'
@@ -69,6 +69,7 @@ helm upgrade --install openftth-tilegenerator dax/tippecanoe \
 helm upgrade --install openftth-tileserver dax/mbtileserver \
   --namespace openftth \
   --set storage.claimName=openftth-tilegenerator-tippecanoe \
+  --set image.repository=maptiler/tileserver-gl
   --set service.type=ClusterIP \
   --set 'commandArgs={-v, -d, /data}'
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,10 +60,10 @@ helm install openftth openftth --namespace openftth
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
      --set schedule="*/10 * * * *" \
-     --set commandArgs='tippecanoe -zg -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force' \
+     --set commandArgs='tippecanoe -z24 -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force' \
      --set storage.enabled=true \
      --set gdal.enabled=true \
-     --set gdal.commandArgs='ogr2ogr -f GeoJSON /data/output.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment"'
+     --set gdal.commandArgs='ogr2ogr -f GeoJSON /data/output.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment WHERE route_network.route_segment.marked_to_be_deleted = false"'
 
 # Install Mbtileserver
 helm upgrade --install openftth-tileserver dax/mbtileserver \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,7 +60,7 @@ helm install openftth openftth --namespace openftth
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
      --set schedule="*/10 * * * *" \
-     --set commandArgs='tippecanoe -z24 -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force' \
+     --set commandArgs='tippecanoe -z24 --generate-ids -o /data/out.mbtiles --drop-densest-as-needed /data/output.geojson --force '  \
      --set storage.enabled=true \
      --set gdal.enabled=true \
      --set gdal.commandArgs='ogr2ogr -f GeoJSON /data/output.geojson PG:"host=openftth-postgis dbname=OPEN_FTTH user=postgres password=postgres" -sql "select mrid\, ST_Transform(coord\, 4326) as wkb_geometry from route_network.route_segment WHERE route_network.route_segment.marked_to_be_deleted = false"'
@@ -69,6 +69,7 @@ helm upgrade --install openftth-tilegenerator dax/tippecanoe \
 helm upgrade --install openftth-tileserver dax/mbtileserver \
   --namespace openftth \
   --set storage.claimName=openftth-tilegenerator-tippecanoe \
+  --set service.type=ClusterIP \
   --set 'commandArgs={-v, -d, /data}'
 
 # Install Nginx-Ingress

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,7 +60,7 @@ helm install openftth openftth --namespace openftth
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
      --set schedule="*/30 * * * *" \
-     --set commandArgs='tippecanoe -z22 -Bg --full-detail=10 --low-detail=10 --generate-ids -o /data/route_network.mbtiles /data/route_segments.geojson /data/route_nodes.geojson --force' \
+     --set commandArgs='tippecanoe -z22 -o /data/out.mbtiles /data/out.geojson --force' \
      --set storage.enabled=true \
      --set gdal.enabled=true \
      --set gdal.commandArgs='\

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,7 +68,7 @@ helm upgrade --install openftth-routenetwork-tileserver dax/mbtileserver \
 helm upgrade --install openftth-basemap-tileserver dax/mbtileserver \
   --version 2.2.0 \
   --namespace openftth \
-  --set image.tag=danish-1621934598 \
+  --set image.tag=danish-1621954230 \
   --set service.type=NodePort \
   --set storage.enabled=false \
   --set 'commandArgs={--enable-reload-signal, -d, /tilesets}' \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,9 +60,7 @@ helm install openftth openftth --namespace openftth
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \
      --namespace openftth \
      --set schedule="*/30 * * * *" \
-     --set commandArgs='\
-           tippecanoe -z22 --full-detail=10 --low-detail=10 --generate-ids -o /data/route_segments.mbtiles /data/route_segments.geojson --force && \
-           tippecanoe -z22 -Bg --full-detail=10 --low-detail=10 --generate-ids -o /data/route_nodes.mbtiles /data/route_nodes.geojson --force'  \
+     --set commandArgs='tippecanoe -z22 -Bg --full-detail=10 --low-detail=10 --generate-ids -o /data/route_network.mbtiles /data/route_segments.geojson /data/route_nodes.geojson --force' \
      --set storage.enabled=true \
      --set gdal.enabled=true \
      --set gdal.commandArgs='\
@@ -75,9 +73,8 @@ helm upgrade --install openftth-tilegenerator dax/tippecanoe \
 helm upgrade --install openftth-tileserver dax/mbtileserver \
   --namespace openftth \
   --set storage.claimName=openftth-tilegenerator-tippecanoe \
-  --set image.repository=maptiler/tileserver-gl
   --set service.type=ClusterIP \
-  --set 'commandArgs={-v, -d, /data}'
+  --set 'commandArgs={-d, /data}'
 
 # Install Nginx-Ingress
 helm install nginx-ingress ingress-nginx/ingress-nginx \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -58,7 +58,7 @@ helm install openftth openftth --namespace openftth
 
 # Install Mbtileserver route-network
 helm upgrade --install openftth-routenetwork-tileserver dax/mbtileserver \
-  --version 2.1.0 \
+  --version 2.2.0 \
   --namespace openftth \
   --set service.type=NodePort \
   --set storage.size=1Gi \
@@ -66,12 +66,13 @@ helm upgrade --install openftth-routenetwork-tileserver dax/mbtileserver \
 
 # Install Mbtileserver base-map
 helm upgrade --install openftth-basemap-tileserver dax/mbtileserver \
-  --version 2.1.0 \
+  --version 2.2.0 \
   --namespace openftth \
   --set image.tag=danish-1621934598 \
-  --set service.type=LoadBalancer \
+  --set service.type=NodePort \
   --set storage.enabled=false \
-  --set 'commandArgs={--enable-reload-signal, -d, /tilesets}'
+  --set 'commandArgs={--enable-reload-signal, -d, /tilesets}' \
+  --set reload.enabled=false
 
 # Install Tippecanoe
 helm upgrade --install openftth-tilegenerator dax/tippecanoe \


### PR DESCRIPTION
This update includes an added tileserver for the routenetwork. The tiles are generated every 30 mins right now and the tileserver is automatic reloaded. The update also includes an tileserver with a basemap instead of having to rely on a third party service.