### PR TITLE
never automatic restart gdb-integrator

### DIFF
--- a/openftth/Chart.yaml
+++ b/openftth/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openftth
 appVersion: "0.5.0"
 description: A Helm chart for openftth
-version: 0.10.216
+version: 0.10.217
 type: application

--- a/openftth/charts/gdb-integrator/Chart.yaml
+++ b/openftth/charts/gdb-integrator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gdb-integrator
 appVersion: "4.10.5"
 description: A Helm chart for gdb-integrator
-version: 0.2.1
+version: 0.3.0
 type: application

--- a/openftth/charts/gdb-integrator/templates/deployment.yaml
+++ b/openftth/charts/gdb-integrator/templates/deployment.yaml
@@ -78,4 +78,4 @@ spec:
           value: "domain.route-network"
         - name: KAFKA__EVENTGEOGRAPHICALAREAUPDATED
           value: "notification.geographical-area-updated"
-      restartPolicy: Always
+      restartPolicy: Never


### PR DESCRIPTION
We don't want it to have automatic restart, because we've a bug where it sometimes start consuming from event 0. This needs to be fixed, but until then we disable the automatic restart.