### PR TITLE
now automatically creates the 'nginx-ingress' namespace

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,6 +21,7 @@ helm upgrade --install strimzi strimzi/strimzi-kafka-operator \
      --version 0.26.1
 
 # Install Nginx-Ingress
+kubectl create namespace nginx-ingress --dry-run=client -o yaml | kubectl apply -f -
 helm upgrade --install nginx-ingress ingress-nginx/ingress-nginx \
     --version 4.0.16 \
     --namespace nginx-ingress \


### PR DESCRIPTION
Doing initial setup of development environment the 'nginx-ingress' namespace was not created. It is now created if it does not already exist when calling the 'setup.sh' script.